### PR TITLE
Some dependency upgrades and bumping go version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# ide specific
+.idea

--- a/counter.go
+++ b/counter.go
@@ -1,7 +1,7 @@
 package micrometer
 
 import (
-	ga "github.com/linxGnu/go-adder"
+	"go.uber.org/atomic"
 )
 
 type (
@@ -13,7 +13,7 @@ type (
 
 	counter struct {
 		id *ID
-		v  ga.Float64Adder
+		v  *atomic.Float64
 	}
 )
 
@@ -37,12 +37,12 @@ func (p *counter) Increment(amount float64) {
 }
 
 func (p *counter) Count() float64 {
-	return p.v.Sum()
+	return p.v.Load()
 }
 
 func NewCounter(id *ID) Counter {
 	return &counter{
 		id: id,
-		v:  ga.NewJDKF64Adder(),
+		v:  atomic.NewFloat64(0),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,13 @@
 module github.com/jjeffcaii/micrometer-go
 
-go 1.12
+go 1.20
 
 require (
-	github.com/linxGnu/go-adder v0.1.13
 	github.com/stretchr/testify v1.3.0
-	github.com/valyala/fastrand v1.0.0 // indirect
+	go.uber.org/atomic v1.11.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,10 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/linxGnu/go-adder v0.1.13 h1:ULKwcifOMKgPz7qspao6vEbsPJQ4mDLuXAKLx8dflGE=
-github.com/linxGnu/go-adder v0.1.13/go.mod h1:HsQtJ1VSU8rGCu8fwH/nO+9VyhyEIZC9y2c4OKqTzAU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/valyala/fastrand v1.0.0 h1:LUKT9aKer2dVQNUi3waewTbKV+7H17kvWFNKs2ObdkI=
-github.com/valyala/fastrand v1.0.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=


### PR DESCRIPTION
Upgraded to go 1.20, migrated from linxGnu/go-adder to go.uber.org/atomic for a more supported library)